### PR TITLE
Ability to to add an optional Package Name

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -4,6 +4,9 @@ register:
         package_id:
             description: The id of the package to track.
             example: "123456789"
+            required: true
+        package_name:
+            description: Opional, easy to remeber name for package. If provided, the entity name will be set to this.
 
 unregister:
     description: Stop tracking a package
@@ -11,3 +14,4 @@ unregister:
         package_id:
             description: The id of the package to stop to track.
             example: "123456789"
+            required: true


### PR DESCRIPTION
Package registration accepts an optional `package_name`. If provided, the entity name would be set to `Package <Package Name>`, otherwise no change to functionality.

- This makes it easier to provide a name to tracked package, which help identity them better. 
- The change automatically migrated old internal storage structure
